### PR TITLE
Osquerybeat: add extension uptycs/kubequery

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "x-pack/osquerybeat/ext/kubequery"]
+	path = x-pack/osquerybeat/ext/kubequery
+	url = https://github.com/Uptycs/kubequery.git

--- a/x-pack/osquerybeat/.gitignore
+++ b/x-pack/osquerybeat/.gitignore
@@ -14,5 +14,8 @@
 /osquery-extension.ext
 /osquery-extension.exe
 
+/kubequery.ext
+/kubequery.exe
+
 # VSCode
 .vscode/

--- a/x-pack/osquerybeat/internal/osqd/osqueryd_unix.go
+++ b/x-pack/osquerybeat/internal/osqd/osqueryd_unix.go
@@ -17,8 +17,11 @@ import (
 	"github.com/pkg/errors"
 )
 
-const (
-	extensionName = "osquery-extension.ext"
+var (
+	extensionNames = []string{
+		"osquery-extension.ext",
+		"kubequery.ext",
+	}
 )
 
 func CreateSocketPath() (string, func(), error) {

--- a/x-pack/osquerybeat/internal/osqd/osqueryd_windows.go
+++ b/x-pack/osquerybeat/internal/osqd/osqueryd_windows.go
@@ -15,8 +15,11 @@ import (
 	"github.com/gofrs/uuid"
 )
 
-const (
-	extensionName = "osquery-extension.exe"
+var (
+	extensionNames = []string{
+		"osquery-extension.exe",
+		"kubequery.exe",
+	}
 )
 
 func CreateSocketPath() (string, func(), error) {

--- a/x-pack/osquerybeat/magefile.go
+++ b/x-pack/osquerybeat/magefile.go
@@ -55,9 +55,26 @@ func Build() error {
 		return err
 	}
 
-	// Rename osquery-extension to osquery-extension.ext on non windows platforms
+	params.WorkDir = "./ext/kubequery"
+	params.InputFiles = []string{"./cmd/kubequery"}
+	params.OutputDir = "bin"
+	params.Name = "kubequery"
+	params.CGO = false
+	err = devtools.Build(params)
+	if err != nil {
+		return err
+	}
+
+	err = os.Rename("./ext/kubequery/bin/kubequery", "kubequery")
+
+	// Append .ext to extensions on non windows platforms.
 	if runtime.GOOS != "windows" {
 		err = os.Rename("osquery-extension", "osquery-extension.ext")
+		if err != nil {
+			return err
+		}
+
+		err = os.Rename("kubequery", "kubequery.ext")
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## What does this PR do?

This is a candidate PR to integrate https://github.com/Uptycs/kubequery into osquerybeat as an extension.

_This is a work in progress._

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

There are some teams, such as Cloud Security Posture, who need Kube API information to be sent from client clusters to Elasticsearch. Leveraging the existing open source extension https://github.com/Uptycs/kubequery and combining it with osquerybeat is a good way to achieve this.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

The changes done to achieve this are broadly as follows. Please advise for each of them if its the best way forward.

1. [ ] Bring the https://github.com/Uptycs/kubequery repository into osquerybeat as a submodule.
2. [ ] Add an option `WorkDir` to the beats build library. This allows for running Go build in a specific working directory, an option that I couldn't find in the library.
3. [ ] Update the Mage build to include building the new extensions.
4. [ ] Update osquerybeat's runtime extension handling to have multiple "mandatory beats", rather than just one.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

`mage build` for osquerybeat should show that it's building kubequery as well, and the binary for the extension should show up in the osquerybeat directory.

Running the osquerybeat binary should show debug logs for kubequery plugins being registered, or errors if for example the Kube configuration file is not present/doesn't work.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->



## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
