### PR TITLE
Modify Fetcher interface and implementations.

### DIFF
--- a/kubebeat/beater/data.go
+++ b/kubebeat/beater/data.go
@@ -140,6 +140,6 @@ func copy(m map[string]interface{}) (map[string]interface{}, error) {
 
 func init() {
 	gob.Register([]interface{}{})
-	gob.Register(map[string]Process{})
+	gob.Register(Process{})
 	gob.Register([]FileSystemResourceData{})
 }

--- a/kubebeat/beater/fetcher.go
+++ b/kubebeat/beater/fetcher.go
@@ -2,6 +2,6 @@ package beater
 
 // Fetcher represents a data fetcher.
 type Fetcher interface {
-	Fetch() (interface{}, error)
+	Fetch() ([]interface{}, error)
 	Stop()
 }

--- a/kubebeat/beater/file_system_fetcher.go
+++ b/kubebeat/beater/file_system_fetcher.go
@@ -1,11 +1,12 @@
 package beater
 
 import (
-	"github.com/elastic/beats/v7/libbeat/logp"
 	"os"
 	"os/user"
 	"strconv"
 	"syscall"
+
+	"github.com/elastic/beats/v7/libbeat/logp"
 )
 
 // FileSystemFetcher implement the Fetcher interface
@@ -36,8 +37,8 @@ func NewFileFetcher(filesPaths []string) Fetcher {
 	}
 }
 
-func (f *FileSystemFetcher) Fetch() (interface{}, error) {
-	results := make([]FileSystemResourceData, 0)
+func (f *FileSystemFetcher) Fetch() ([]interface{}, error) {
+	results := make([]interface{}, 0)
 
 	for _, filePath := range f.filesPaths {
 		info, err := os.Stat(filePath)

--- a/kubebeat/beater/file_system_fetcher_test.go
+++ b/kubebeat/beater/file_system_fetcher_test.go
@@ -1,11 +1,12 @@
 package beater
 
 import (
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestFileFetcherFetchFilesFromFileSystem(t *testing.T) {
@@ -18,6 +19,8 @@ func TestFileFetcherFetchFilesFromFileSystem(t *testing.T) {
 	defer os.RemoveAll(dir)
 	file := filepath.Join(dir, "file.txt")
 	if err = ioutil.WriteFile(file, []byte("test txt\n"), 0600); err != nil {
+		// TODO(ofir): Used Go native *testing.T for this error, but the testify
+		// assert before. Should use the same in both places.
 		t.Fatal(err)
 	}
 
@@ -26,9 +29,10 @@ func TestFileFetcherFetchFilesFromFileSystem(t *testing.T) {
 	results, err := fileFetcher.Fetch()
 
 	if err != nil {
+		// TODO(ofir): The error err should be included in the failure output.
 		assert.Fail(t, "Fetcher did not work")
 	}
-	result := results.([]FileSystemResourceData)[0]
+	result := results[0].(FileSystemResourceData)
 
 	assert.Equal(t, file, result.Path)
 	assert.Equal(t, "600", result.FileMode)

--- a/kubebeat/beater/kube.go
+++ b/kubebeat/beater/kube.go
@@ -39,7 +39,7 @@ func NewKubeFetcher(kubeconfig string, interval time.Duration) (Fetcher, error) 
 	}, nil
 }
 
-func (f *KubeFetcher) Fetch() (interface{}, error) {
+func (f *KubeFetcher) Fetch() ([]interface{}, error) {
 	pods := f.watcher.Store().List()
 
 	for _, p := range pods {

--- a/kubebeat/beater/process.go
+++ b/kubebeat/beater/process.go
@@ -5,13 +5,15 @@ import (
 )
 
 const (
-	procfsdir = "/hostfs"
+	procfsdir        = "/hostfs"
+	ProcessInputType = "process"
 )
 
 type Process struct {
-	PID  string        `json:"pid"`
-	Cmd  string        `json:"cmd"`
-	Stat proc.ProcStat `json:"stat"`
+	InputType string        `json:"inputType"`
+	PID       string        `json:"pid"`
+	Cmd       string        `json:"cmd"`
+	Stat      proc.ProcStat `json:"stat"`
 }
 
 type ProcessesFetcher struct {
@@ -24,13 +26,13 @@ func NewProcessesFetcher(dir string) Fetcher {
 	}
 }
 
-func (f *ProcessesFetcher) Fetch() (interface{}, error) {
+func (f *ProcessesFetcher) Fetch() ([]interface{}, error) {
 	pids, err := proc.List(f.directory)
 	if err != nil {
 		return nil, err
 	}
 
-	ret := make(map[string]Process)
+	ret := make([]interface{}, 0)
 
 	// If errors occur during read, then return what we have till now
 	// without reporting errors.
@@ -45,7 +47,7 @@ func (f *ProcessesFetcher) Fetch() (interface{}, error) {
 			return ret, nil
 		}
 
-		ret[p] = Process{p, cmd, stat}
+		ret = append(ret, Process{ProcessInputType, p, cmd, stat})
 	}
 
 	return ret, nil


### PR DESCRIPTION
Fetcher.Fetch() not returns a slice. The main idea is that Fetcher
implementations should define what the atomic unit of 'resource'
to be consumed by OPA is.