### PR TITLE
Add leader election logic

### DIFF
--- a/kubebeat/beater/evaluation_result_parser.go
+++ b/kubebeat/beater/evaluation_result_parser.go
@@ -1,10 +1,10 @@
 package beater
 
 import (
-	libevents "github.com/elastic/beats/v7/libbeat/beat/events"
 	"time"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
+	libevents "github.com/elastic/beats/v7/libbeat/beat/events"
 	"github.com/elastic/beats/v7/libbeat/common"
 
 	"github.com/gofrs/uuid"

--- a/kubebeat/beater/kube_lease.go
+++ b/kubebeat/beater/kube_lease.go
@@ -1,0 +1,68 @@
+package beater
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/elastic/beats/v7/libbeat/common/kubernetes"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8s "k8s.io/client-go/kubernetes"
+)
+
+const (
+	PodNameEnvar           = "POD_NAME"
+	DefaultLeaderLeaseName = "elastic-agent-cluster-leader"
+)
+
+type LeaseInfo struct {
+	ctx    context.Context
+	client k8s.Interface
+}
+
+func NewLeaseInfo(ctx context.Context) (*LeaseInfo, error) {
+	c, err := kubernetes.GetKubernetesClient("", kubernetes.KubeClientOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	return &LeaseInfo{ctx, c}, nil
+}
+
+func (l *LeaseInfo) IsLeader() (bool, error) {
+	leases, err := l.client.CoordinationV1().Leases(kubeSystemNamespace).List(l.ctx, v1.ListOptions{})
+	if err != nil {
+		return false, err
+	}
+
+	for _, lease := range leases.Items {
+		if lease.Name == DefaultLeaderLeaseName {
+			podid := lastPart(*lease.Spec.HolderIdentity)
+
+			if podid == l.currentPodID() {
+				return true, nil
+			}
+
+			return false, nil
+		}
+	}
+
+	return false, fmt.Errorf("could not find lease %v in Kube leases", DefaultLeaderLeaseName)
+}
+
+func (l *LeaseInfo) currentPodID() string {
+	pod := os.Getenv(PodNameEnvar)
+
+	return lastPart(pod)
+}
+
+func lastPart(s string) string {
+	parts := strings.Split(s, "-")
+	if len(parts) == 0 {
+		return ""
+	}
+
+	return parts[len(parts)-1]
+}

--- a/kubebeat/beater/kubebeat.go
+++ b/kubebeat/beater/kubebeat.go
@@ -41,7 +41,11 @@ func New(b *beat.Beat, cfg *common.Config) (beat.Beater, error) {
 
 	logp.Info("Config initiated.")
 
-	data := NewData(ctx, c.Period)
+	data, err := NewData(ctx, c.Period)
+	if err != nil {
+		return nil, err
+	}
+
 	scheduler := NewSynchronousScheduler()
 	evaluator, err := NewEvaluator()
 	if err != nil {
@@ -60,9 +64,9 @@ func New(b *beat.Beat, cfg *common.Config) (beat.Beater, error) {
 		return nil, err
 	}
 
-	data.RegisterFetcher("kube_api", kubef)
-	data.RegisterFetcher("processes", NewProcessesFetcher(procfsdir))
-	data.RegisterFetcher("file_system", NewFileFetcher(c.Files))
+	data.RegisterFetcher("kube_api", kubef, true)
+	data.RegisterFetcher("processes", NewProcessesFetcher(procfsdir), false)
+	data.RegisterFetcher("file_system", NewFileFetcher(c.Files), false)
 
 	bt := &kubebeat{
 		done:         make(chan struct{}),

--- a/kubebeat/beater/process.go
+++ b/kubebeat/beater/process.go
@@ -5,15 +5,15 @@ import (
 )
 
 const (
-	procfsdir        = "/hostfs"
-	ProcessInputType = "process"
+	procfsdir   = "/hostfs"
+	ProcessType = "process"
 )
 
 type Process struct {
-	InputType string        `json:"type"`
-	PID       string        `json:"pid"`
-	Cmd       string        `json:"command"`
-	Stat      proc.ProcStat `json:"stat"`
+	Type string        `json:"type"`
+	PID  string        `json:"pid"`
+	Cmd  string        `json:"command"`
+	Stat proc.ProcStat `json:"stat"`
 }
 
 type ProcessesFetcher struct {
@@ -47,7 +47,7 @@ func (f *ProcessesFetcher) Fetch() ([]interface{}, error) {
 			return ret, nil
 		}
 
-		ret = append(ret, Process{ProcessInputType, p, cmd, stat})
+		ret = append(ret, Process{ProcessType, p, cmd, stat})
 	}
 
 	return ret, nil


### PR DESCRIPTION
The simplest way to use existing Kubernetes leader election capabilities implemented by Elastic Agent is to publish the status to the environment using environment variable.

This is then consumed by our beat.