### PR TITLE
Use a single context where possible.

### DIFF
--- a/kubebeat/opa/evaluator.go
+++ b/kubebeat/opa/evaluator.go
@@ -17,7 +17,7 @@ type Evaluator struct {
 	opa          *sdk.OPA
 }
 
-func NewEvaluator() (*Evaluator, error) {
+func NewEvaluator(ctx context.Context) (*Evaluator, error) {
 	server, err := bundle.StartServer()
 	if err != nil {
 		return nil, err
@@ -30,7 +30,7 @@ func NewEvaluator() (*Evaluator, error) {
 
 	// create an instance of the OPA object
 	opaLogger := newEvaluatorLogger()
-	opa, err := sdk.New(context.Background(), sdk.Options{
+	opa, err := sdk.New(ctx, sdk.Options{
 		Config: bytes.NewReader(config),
 		Logger: opaLogger,
 	})
@@ -44,9 +44,9 @@ func NewEvaluator() (*Evaluator, error) {
 	}, nil
 }
 
-func (e *Evaluator) Decision(input interface{}) (interface{}, error) {
+func (e *Evaluator) Decision(ctx context.Context, input interface{}) (interface{}, error) {
 	// get the named policy decision for the specified input
-	result, err := e.opa.Decision(context.Background(), sdk.DecisionOptions{
+	result, err := e.opa.Decision(ctx, sdk.DecisionOptions{
 		Path:  "main",
 		Input: input,
 	})
@@ -57,8 +57,7 @@ func (e *Evaluator) Decision(input interface{}) (interface{}, error) {
 	return result.Result, nil
 }
 
-func (e *Evaluator) Stop() {
-	ctx := context.Background()
+func (e *Evaluator) Stop(ctx context.Context) {
 	e.opa.Stop(ctx)
 	e.bundleServer.Shutdown(ctx)
 }

--- a/kubebeat/resources/data_test.go
+++ b/kubebeat/resources/data_test.go
@@ -24,16 +24,19 @@ func TestDataRun(t *testing.T) {
 
 	reg := NewFetcherRegistry()
 	registerNFetchers(t, reg, fetcherCount)
-	d, err := NewData(context.Background(), duration, reg)
+	d, err := NewData(duration, reg)
 	if err != nil {
 		t.Error(err)
 	}
 
-	err = d.Run()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err = d.Run(ctx)
 	if err != nil {
 		return
 	}
-	defer d.Stop()
+	defer d.Stop(ctx, cancel)
 
 	o := d.Output()
 	state := <-o

--- a/kubebeat/resources/fetcher.go
+++ b/kubebeat/resources/fetcher.go
@@ -1,10 +1,14 @@
 package resources
 
-import "github.com/elastic/beats/v7/x-pack/osquerybeat/ext/osquery-extension/pkg/proc"
+import (
+	"context"
+
+	"github.com/elastic/beats/v7/x-pack/osquerybeat/ext/osquery-extension/pkg/proc"
+)
 
 // Fetcher represents a data fetcher.
 type Fetcher interface {
-	Fetch() ([]FetcherResult, error)
+	Fetch(context.Context) ([]FetcherResult, error)
 	Stop()
 }
 

--- a/kubebeat/resources/fetchers/ecr_fetcher.go
+++ b/kubebeat/resources/fetchers/ecr_fetcher.go
@@ -21,9 +21,9 @@ func NewECRFetcher(cfg aws.Config) (resources.Fetcher, error) {
 	}, nil
 }
 
-func (f ECRFetcher) Fetch() ([]resources.FetcherResult, error) {
+func (f ECRFetcher) Fetch(ctx context.Context) ([]resources.FetcherResult, error) {
 	results := make([]resources.FetcherResult, 0)
-	ctx := context.Background()
+
 	// TODO - The provider should get a list of the repositories it needs to check, and not check the entire ECR account`
 	repositories, err := f.ecrProvider.DescribeAllECRRepositories(ctx)
 	results = append(results, resources.FetcherResult{

--- a/kubebeat/resources/fetchers/eks_fetcher.go
+++ b/kubebeat/resources/fetchers/eks_fetcher.go
@@ -23,9 +23,9 @@ func NewEKSFetcher(cfg aws.Config, clusterName string) (resources.Fetcher, error
 	}, nil
 }
 
-func (f EKSFetcher) Fetch() ([]resources.FetcherResult, error) {
+func (f EKSFetcher) Fetch(ctx context.Context) ([]resources.FetcherResult, error) {
 	results := make([]resources.FetcherResult, 0)
-	ctx := context.Background()
+
 	result, err := f.eksProvider.DescribeCluster(ctx, f.clusterName)
 	results = append(results, resources.FetcherResult{
 		Type:     EKSType,

--- a/kubebeat/resources/fetchers/elb_fetcher.go
+++ b/kubebeat/resources/fetchers/elb_fetcher.go
@@ -23,9 +23,9 @@ func NewELBFetcher(cfg aws.Config, loadBalancersNames []string) (resources.Fetch
 	}, nil
 }
 
-func (f ELBFetcher) Fetch() ([]resources.FetcherResult, error) {
+func (f ELBFetcher) Fetch(ctx context.Context) ([]resources.FetcherResult, error) {
 	results := make([]resources.FetcherResult, 0)
-	ctx := context.Background()
+
 	result, err := f.elbProvider.DescribeLoadBalancer(ctx, f.lbNames)
 	results = append(results, resources.FetcherResult{
 		Type:     ELBType,

--- a/kubebeat/resources/fetchers/file_system_fetcher.go
+++ b/kubebeat/resources/fetchers/file_system_fetcher.go
@@ -1,6 +1,7 @@
 package fetchers
 
 import (
+	"context"
 	"os"
 	"os/user"
 	"strconv"
@@ -27,7 +28,7 @@ func NewFileFetcher(filesPaths []string) resources.Fetcher {
 	}
 }
 
-func (f *FileSystemFetcher) Fetch() ([]resources.FetcherResult, error) {
+func (f *FileSystemFetcher) Fetch(ctx context.Context) ([]resources.FetcherResult, error) {
 	results := make([]resources.FetcherResult, 0)
 
 	// Input files might contain glob pattern

--- a/kubebeat/resources/fetchers/file_system_fetcher_test.go
+++ b/kubebeat/resources/fetchers/file_system_fetcher_test.go
@@ -1,11 +1,13 @@
 package fetchers
 
 import (
-	"github.com/elastic/beats/v7/kubebeat/resources"
+	"context"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/elastic/beats/v7/kubebeat/resources"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -18,7 +20,7 @@ func TestFileFetcherFetchASingleFile(t *testing.T) {
 
 	filePaths := []string{filepath.Join(dir, files[0])}
 	fileFetcher := NewFileFetcher(filePaths)
-	results, err := fileFetcher.Fetch()
+	results, err := fileFetcher.Fetch(context.TODO())
 
 	assert.Nil(t, err, "Fetcher was not able to fetch files from FS")
 	assert.Equal(t, 1, len(results))
@@ -36,7 +38,7 @@ func TestFileFetcherFetchTwoPatterns(t *testing.T) {
 
 	path := []string{filepath.Join(outerDir, outerFiles[0]), filepath.Join(outerDir, outerFiles[1])}
 	fileFetcher := NewFileFetcher(path)
-	results, err := fileFetcher.Fetch()
+	results, err := fileFetcher.Fetch(context.TODO())
 
 	assert.Nil(t, err, "Fetcher was not able to fetch files from FS")
 	assert.Equal(t, 2, len(results))
@@ -58,7 +60,7 @@ func TestFileFetcherFetchDirectoryOnly(t *testing.T) {
 
 	filePaths := []string{filepath.Join(dir)}
 	fileFetcher := NewFileFetcher(filePaths)
-	results, err := fileFetcher.Fetch()
+	results, err := fileFetcher.Fetch(context.TODO())
 
 	assert.Nil(t, err, "Fetcher was not able to fetch files from FS")
 	assert.Equal(t, 1, len(results))
@@ -80,7 +82,7 @@ func TestFileFetcherFetchOuterDirectoryOnly(t *testing.T) {
 
 	path := []string{outerDir + "/*"}
 	fileFetcher := NewFileFetcher(path)
-	results, err := fileFetcher.Fetch()
+	results, err := fileFetcher.Fetch(context.TODO())
 
 	assert.Nil(t, err, "Fetcher was not able to fetch files from FS")
 	assert.Equal(t, 2, len(results))
@@ -109,7 +111,7 @@ func TestFileFetcherFetchDirectoryRecursively(t *testing.T) {
 
 	path := []string{outerDir + "/**"}
 	fileFetcher := NewFileFetcher(path)
-	results, err := fileFetcher.Fetch()
+	results, err := fileFetcher.Fetch(context.TODO())
 
 	assert.Nil(t, err, "Fetcher was not able to fetch files from FS")
 	assert.Equal(t, 6, len(results))

--- a/kubebeat/resources/fetchers/iam_fetcher.go
+++ b/kubebeat/resources/fetchers/iam_fetcher.go
@@ -23,9 +23,9 @@ func NewIAMFetcher(cfg aws.Config, roleName string) (resources.Fetcher, error) {
 	}, nil
 }
 
-func (f IAMFetcher) Fetch() ([]resources.FetcherResult, error) {
+func (f IAMFetcher) Fetch(ctx context.Context) ([]resources.FetcherResult, error) {
 	results := make([]resources.FetcherResult, 0)
-	ctx := context.Background()
+
 	result, err := f.iamProvider.GetIAMRolePermissions(ctx, f.roleName)
 	results = append(results, resources.FetcherResult{
 		Type:     IAMType,

--- a/kubebeat/resources/fetchers/kube.go
+++ b/kubebeat/resources/fetchers/kube.go
@@ -1,6 +1,7 @@
 package fetchers
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
@@ -132,7 +133,7 @@ func (f *KubeFetcher) initWatchers() error {
 	return nil
 }
 
-func (f *KubeFetcher) Fetch() ([]resources.FetcherResult, error) {
+func (f *KubeFetcher) Fetch(ctx context.Context) ([]resources.FetcherResult, error) {
 	var err error
 	watcherlock.Do(func() {
 		err = f.initWatchers()

--- a/kubebeat/resources/fetchers/process.go
+++ b/kubebeat/resources/fetchers/process.go
@@ -1,6 +1,8 @@
 package fetchers
 
 import (
+	"context"
+
 	"github.com/elastic/beats/v7/kubebeat/resources"
 	"github.com/elastic/beats/v7/x-pack/osquerybeat/ext/osquery-extension/pkg/proc"
 )
@@ -19,7 +21,7 @@ func NewProcessesFetcher(dir string) resources.Fetcher {
 	}
 }
 
-func (f *ProcessesFetcher) Fetch() ([]resources.FetcherResult, error) {
+func (f *ProcessesFetcher) Fetch(ctx context.Context) ([]resources.FetcherResult, error) {
 	pids, err := proc.List(f.directory)
 	if err != nil {
 		return nil, err

--- a/kubebeat/resources/registry_test.go
+++ b/kubebeat/resources/registry_test.go
@@ -1,6 +1,7 @@
 package resources
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -17,7 +18,7 @@ func newNumberFetcher(num int) Fetcher {
 	return &numberFetcher{num, false}
 }
 
-func (f *numberFetcher) Fetch() ([]FetcherResult, error) {
+func (f *numberFetcher) Fetch(ctx context.Context) ([]FetcherResult, error) {
 	return fetchValue(f.num), nil
 }
 
@@ -122,7 +123,7 @@ func (s *RegistryTestSuite) TestRunNotRegistered() {
 	err := s.registry.Register("some-key", f)
 	s.NoError(err)
 
-	arr, err := s.registry.Run("unknown")
+	arr, err := s.registry.Run(context.TODO(), "unknown")
 	s.Error(err)
 	s.Empty(arr)
 }
@@ -156,7 +157,7 @@ func (s *RegistryTestSuite) TestRunRegistered() {
 	}
 
 	for _, test := range tests {
-		arr, err := s.registry.Run(test.key)
+		arr, err := s.registry.Run(context.TODO(), test.key)
 		s.NoError(err)
 		s.Equal(1, len(arr))
 		s.Equal(test.value, arr[0].Resource)


### PR DESCRIPTION
New contexts were being created in our beat where they shouldn't be.