### PR TITLE
split kube to fetcher & provider and nullify ManagedFields

### DIFF
--- a/kubebeat/resources/fetchers/kube_fetcher.go
+++ b/kubebeat/resources/fetchers/kube_fetcher.go
@@ -142,7 +142,7 @@ func (f *KubeFetcher) Fetch(ctx context.Context) ([]resources.FetcherResult, err
 		return nil, fmt.Errorf("could not initate Kubernetes watchers: %w", err)
 	}
 
-	return GetKubeData(f.watchers)
+	return GetKubeData(f.watchers), nil
 }
 
 func (f *KubeFetcher) Stop() {

--- a/kubebeat/resources/fetchers/kube_fetcher.go
+++ b/kubebeat/resources/fetchers/kube_fetcher.go
@@ -16,9 +16,8 @@ import (
 )
 
 const (
-	KubeAPIType         = "kube-api"
-	kubeSystemNamespace = "kube-system"
-	allNamespaces       = "" // The Kube API treats this as "all namespaces"
+	KubeAPIType   = "kube-api"
+	allNamespaces = "" // The Kube API treats this as "all namespaces"
 )
 
 var (
@@ -30,7 +29,6 @@ var (
 			allNamespaces,
 		},
 		{
-
 			&kubernetes.Secret{},
 			allNamespaces,
 		},
@@ -87,7 +85,7 @@ func NewKubeFetcher(kubeconfig string, interval time.Duration) (resources.Fetche
 }
 
 func (f *KubeFetcher) initWatcher(client k8s.Interface, r requiredResource) error {
-	w, err := kubernetes.NewWatcher(client, r.resource, kubernetes.WatchOptions{
+	watcher, err := kubernetes.NewWatcher(client, r.resource, kubernetes.WatchOptions{
 		SyncTimeout: f.interval,
 		Namespace:   r.namespace,
 	}, nil)
@@ -102,11 +100,11 @@ func (f *KubeFetcher) initWatcher(client k8s.Interface, r requiredResource) erro
 	// When such a failure happens, kubebeat won't shut down gracefuly, i.e. Stop will not work. This
 	// happens due to a context.TODO present in the libbeat dependency. It needs to accept context
 	// from the caller instead.
-	if err := w.Start(); err != nil {
+	if err := watcher.Start(); err != nil {
 		return fmt.Errorf("could not start watcher: %w", err)
 	}
 
-	f.watchers = append(f.watchers, w)
+	f.watchers = append(f.watchers, watcher)
 
 	return nil
 }
@@ -144,53 +142,31 @@ func (f *KubeFetcher) Fetch(ctx context.Context) ([]resources.FetcherResult, err
 		return nil, fmt.Errorf("could not initate Kubernetes watchers: %w", err)
 	}
 
-	ret := make([]resources.FetcherResult, 0)
-
-	for _, w := range f.watchers {
-		rs := w.Store().List()
-
-		for _, r := range rs {
-			o, ok := r.(runtime.Object)
-
-			if !ok {
-				logp.L().Errorf("Bad resource: %#v does not implement runtime.Object", r)
-				continue
-			}
-
-			addTypeInformationToObject(o) // See https://github.com/kubernetes/kubernetes/issues/3030
-
-			ret = append(ret, resources.FetcherResult{
-				Type:     KubeAPIType,
-				Resource: o,
-			})
-		}
-	}
-
-	return ret, nil
+	return GetKubeData(f.watchers)
 }
 
 func (f *KubeFetcher) Stop() {
-	for _, w := range f.watchers {
-		w.Stop()
+	for _, watcher := range f.watchers {
+		watcher.Stop()
 	}
 }
 
-// addTypeInformationToObject adds TypeMeta information to a runtime.Object based upon the loaded scheme.Scheme
+// addTypeInformationToKubeResource adds TypeMeta information to a kubernetes.Resource based upon the loaded scheme.Scheme
 // inspired by: https://github.com/kubernetes/cli-runtime/blob/v0.19.2/pkg/printers/typesetter.go#L41
-func addTypeInformationToObject(obj runtime.Object) error {
-	gvks, _, err := scheme.Scheme.ObjectKinds(obj)
+func addTypeInformationToKubeResource(resource kubernetes.Resource) error {
+	groupVersionKinds, _, err := scheme.Scheme.ObjectKinds(resource)
 	if err != nil {
 		return fmt.Errorf("missing apiVersion or kind and cannot assign it; %w", err)
 	}
 
-	for _, gvk := range gvks {
-		if len(gvk.Kind) == 0 {
+	for _, groupVersionKind := range groupVersionKinds {
+		if len(groupVersionKind.Kind) == 0 {
 			continue
 		}
-		if len(gvk.Version) == 0 || gvk.Version == runtime.APIVersionInternal {
+		if len(groupVersionKind.Version) == 0 || groupVersionKind.Version == runtime.APIVersionInternal {
 			continue
 		}
-		obj.GetObjectKind().SetGroupVersionKind(gvk)
+		resource.GetObjectKind().SetGroupVersionKind(groupVersionKind)
 		break
 	}
 

--- a/kubebeat/resources/fetchers/kube_provider.go
+++ b/kubebeat/resources/fetchers/kube_provider.go
@@ -6,7 +6,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/logp"
 )
 
-func GetKubeData(watchers []kubernetes.Watcher) ([]resources.FetcherResult, error) {
+func GetKubeData(watchers []kubernetes.Watcher) []resources.FetcherResult {
 	ret := make([]resources.FetcherResult, 0)
 
 	for _, watcher := range watchers {
@@ -23,7 +23,8 @@ func GetKubeData(watchers []kubernetes.Watcher) ([]resources.FetcherResult, erro
 
 			err := addTypeInformationToKubeResource(resource)
 			if err != nil {
-				return nil, err
+				logp.L().Errorf("Bad resource: %w", err)
+				continue
 			} // See https://github.com/kubernetes/kubernetes/issues/3030
 
 			ret = append(ret, resources.FetcherResult{
@@ -33,7 +34,7 @@ func GetKubeData(watchers []kubernetes.Watcher) ([]resources.FetcherResult, erro
 		}
 	}
 
-	return ret, nil
+	return ret
 }
 
 // nullifyManagedFields ManagedFields field contains fields with dot that prevent from elasticsearch to index

--- a/kubebeat/resources/fetchers/kube_provider.go
+++ b/kubebeat/resources/fetchers/kube_provider.go
@@ -1,0 +1,60 @@
+package fetchers
+
+import (
+	"github.com/elastic/beats/v7/kubebeat/resources"
+	"github.com/elastic/beats/v7/libbeat/common/kubernetes"
+	"github.com/elastic/beats/v7/libbeat/logp"
+)
+
+func GetKubeData(watchers []kubernetes.Watcher) ([]resources.FetcherResult, error) {
+	ret := make([]resources.FetcherResult, 0)
+
+	for _, watcher := range watchers {
+		rs := watcher.Store().List()
+
+		for _, r := range rs {
+			nullifyManagedFields(r)
+			resource, ok := r.(kubernetes.Resource)
+
+			if !ok {
+				logp.L().Errorf("Bad resource: %#v does not implement kubernetes.Resource", r)
+				continue
+			}
+
+			err := addTypeInformationToKubeResource(resource)
+			if err != nil {
+				return nil, err
+			} // See https://github.com/kubernetes/kubernetes/issues/3030
+
+			ret = append(ret, resources.FetcherResult{
+				Type:     KubeAPIType,
+				Resource: resource,
+			})
+		}
+	}
+
+	return ret, nil
+}
+
+// nullifyManagedFields ManagedFields field contains fields with dot that prevent from elasticsearch to index
+// the events.
+func nullifyManagedFields(resource interface{}) {
+	switch val := resource.(type) {
+	case *kubernetes.Pod:
+		val.ManagedFields = nil
+	case *kubernetes.Secret:
+		val.ManagedFields = nil
+	case *kubernetes.Role:
+		val.ManagedFields = nil
+	case *kubernetes.RoleBinding:
+		val.ManagedFields = nil
+	case *kubernetes.ClusterRole:
+		val.ManagedFields = nil
+	case *kubernetes.ClusterRoleBinding:
+		val.ManagedFields = nil
+	case *kubernetes.PodSecurityPolicy:
+		val.ManagedFields = nil
+	case *kubernetes.NetworkPolicy:
+		val.ManagedFields = nil
+	}
+}


### PR DESCRIPTION
- Splits kube.go into kube_fetcher.go & kube_provider.go
- Sets problematic `ManagedFields` into `nil` and by that solving the indexing issue we had
___
- Closes https://github.com/elastic/security-team/issues/2771